### PR TITLE
migration added to change name to them because au DB security on Heroku

### DIFF
--- a/db/migrate/20251009121251_create_scenarios.rb
+++ b/db/migrate/20251009121251_create_scenarios.rb
@@ -1,7 +1,7 @@
 class CreateScenarios < ActiveRecord::Migration[7.1]
   def change
     create_table :scenarios do |t|
-      t.string :theme, null: false
+      t.string :name, null: false
       t.string :difficulty, null: false
       t.text :description
       t.text :duration
@@ -10,7 +10,7 @@ class CreateScenarios < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :scenarios, :theme
+    add_index :scenarios, :name
     add_index :scenarios, :difficulty
   end
 end

--- a/db/migrate/20251009221258_remove_name_from_scenarios.rb
+++ b/db/migrate/20251009221258_remove_name_from_scenarios.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromScenarios < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :scenarios, :name, :string
+  end
+end

--- a/db/migrate/20251009221307_add_theme_to_scenarios.rb
+++ b/db/migrate/20251009221307_add_theme_to_scenarios.rb
@@ -1,0 +1,5 @@
+class AddThemeToScenarios < ActiveRecord::Migration[7.1]
+  def change
+    add_column :scenarios, :theme, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_09_171714) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_09_221307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,15 +51,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_09_171714) do
   end
 
   create_table "scenarios", force: :cascade do |t|
-    t.string "theme", null: false
     t.string "difficulty", null: false
     t.text "description"
     t.text "duration"
     t.integer "total_riddles"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "theme"
     t.index ["difficulty"], name: "index_scenarios_on_difficulty"
-    t.index ["theme"], name: "index_scenarios_on_theme"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Revision des migrations: le champs name ne peut pas être modifié en corrigeant directement une précédente migration car la BDD sur Heroku est protégée et ne peut pas être effacée. Pas de drop, pas de révision de migration

Pour modifier le champs name en thème, il faut ajouter des migrations pour :
- supprimer le champs name
- ajouter le champs theme